### PR TITLE
Set NEW_FUN_TAGS flag during handshake.

### DIFF
--- a/src/Foreign/Erlang/Network.hs
+++ b/src/Foreign/Erlang/Network.hs
@@ -185,7 +185,7 @@ handshake out inf self = do
     sendName = out $
         tag 'n' <>
         putn erlangVersion <>
-        putN (flagExtendedReferences .|. flagExtendedPidsPorts .|. flagUTF8Atoms) <>
+        putN (flagExtendedReferences .|. flagExtendedPidsPorts .|. flagUTF8Atoms .|. flagNewFunTags) <>
         putA self
 
     recvStatus = do


### PR DESCRIPTION
When connecting to an erlang node running version 21, the handshake
would fail with the following error (from the Erlang side):

        ** 'erl@127.0.0.1': Connection attempt from node
        haskell@localhost rejected since it cannot handle
        ["NEW_FUN_TAGS"].**

This commit sets the NEW_FUN_TAGS flag during the handshake which
resolves this error.